### PR TITLE
Fixed addin path on Windows 10 with Office 16

### DIFF
--- a/inc/code.iss
+++ b/inc/code.iss
@@ -251,7 +251,7 @@ begin
 	}
 	if RegisterWithFullPath then
 	begin
-		AddinName := '"' + CurrentFileName + '"';
+		AddinName := '"' + ExpandConstant('{userappdata}\Microsoft\Addins\') + ExtractFileName(CurrentFileName) + '"';
 	end
 	else
 	begin


### PR DESCRIPTION
When installing an addin on a machine running Windows 10 and Office 16 the addin is registered with the path: `GetDestDir\AddinName.xaml.` The addin file does not exist at this path.
To fix the issue register the addin with the path: `{userappdata}\Microsoft\Addins\AddinName.xaml`.